### PR TITLE
Add `aSet` function in Forge

### DIFF
--- a/core/src/main/kotlin/fr/xgouchet/elmyr/Forge.kt
+++ b/core/src/main/kotlin/fr/xgouchet/elmyr/Forge.kt
@@ -973,6 +973,25 @@ open class Forge {
     }
 
     /**
+     * Creates a random set.
+     * @param T The type of elements in the set
+     * @param size the size of the set, or -1 for a random size
+     * @param forging a lambda generating values that will fill the set
+     */
+    fun <T> aSet(size: Int = -1, forging: Forge.() -> T): Set<T> {
+        val setSize = if (size < 0) aTinyInt() else size
+        val set = mutableSetOf<T>()
+        val maxLoopIteration = setSize * 2
+        var index = 0
+        while (set.size < setSize && index < maxLoopIteration) {
+            set.add(this.forging())
+            index ++
+        }
+
+        return set
+    }
+
+    /**
      * Creates a random sequence.
      * @param T The type of elements in the list
      * @param size the size of the sequence, or -1 for a random size

--- a/core/src/test/kotlin/fr/xgouchet/elmyr/ForgeCollectionSpek.kt
+++ b/core/src/test/kotlin/fr/xgouchet/elmyr/ForgeCollectionSpek.kt
@@ -603,6 +603,23 @@ class ForgeCollectionSpek : Spek({
                 assertThat(data).containsExactly(*expectedData)
             }
 
+            it("forges a set of whatever") {
+                var i = 0
+                val data = forge.aSet { anElementFrom((i++ / 2)) }
+                val expectedData = IntArray(data.size) { it }.toTypedArray()
+
+                assertThat(data).containsExactly(*expectedData)
+            }
+
+            it("forges a set of whatever with fixed size") {
+                val size = forge.aTinyInt() + 3
+                var i = 0
+                val data = forge.aSet(size) { anElementFrom((i++ / 2)) }
+                val expectedData = IntArray(size) { it }.toTypedArray()
+
+                assertThat(data).containsExactly(*expectedData)
+            }
+
             it("forges a map of whatever") {
                 var i = 0
                 val data = forge.aMap() { i to "<${i++}>" }


### PR DESCRIPTION
### What?

Add `aSet` function in forge.

### Why?

this function can be used to generate a collection of unique element 

### Reviewer checklist (to be filled by reviewers)

- [ ] All public classes, methods and fields are documented
- [ ] All code is unit tested
- [ ] All code is usable with and without the Android SDK, from Java and Kotlin
