### PR TITLE
Add `aListIndexed` function in Forge

### DIFF
--- a/core/src/main/kotlin/fr/xgouchet/elmyr/Forge.kt
+++ b/core/src/main/kotlin/fr/xgouchet/elmyr/Forge.kt
@@ -962,11 +962,24 @@ open class Forge {
      * @param forging a lambda generating values that will fill the list
      */
     fun <T> aList(size: Int = -1, forging: Forge.() -> T): List<T> {
+        return aListIndexed(size) { _ ->
+            this.forging()
+        }
+    }
+
+    /**
+     * Creates a random list, providing sequential index with the element.
+     * @param T The type of elements in the list
+     * @param size the size of the list, or -1 for a random size
+     * @param forging a lambda generating values that will fill the list, providing sequential
+     * index with the element.
+     */
+    fun <T> aListIndexed(size: Int = -1, forging: Forge.(Int) -> T): List<T> {
         val listSize = if (size < 0) aTinyInt() else size
         val list = ArrayList<T>(listSize)
 
         for (i in 0 until listSize) {
-            list.add(forging(this))
+            list.add(this.forging(i))
         }
 
         return list

--- a/core/src/test/kotlin/fr/xgouchet/elmyr/ForgeCollectionSpek.kt
+++ b/core/src/test/kotlin/fr/xgouchet/elmyr/ForgeCollectionSpek.kt
@@ -620,6 +620,25 @@ class ForgeCollectionSpek : Spek({
                 assertThat(data).containsExactly(*expectedData)
             }
 
+            it("forges an indexed list of whatever") {
+                val data = forge.aListIndexed { index ->
+                    anElementFrom(index)
+                }
+                val expectedData = IntArray(data.size) { it }.toTypedArray()
+
+                assertThat(data).containsExactly(*expectedData)
+            }
+
+            it("forges an indexed list of whatever with fixed size") {
+                val size = forge.aTinyInt() + 3
+                val data = forge.aListIndexed(size) { index ->
+                    anElementFrom(index)
+                }
+                val expectedData = IntArray(size) { it }.toTypedArray()
+
+                assertThat(data).containsExactly(*expectedData)
+            }
+
             it("forges a map of whatever") {
                 var i = 0
                 val data = forge.aMap() { i to "<${i++}>" }


### PR DESCRIPTION
### What?

Add `aListIndexed` function in Forge.

### Why?

`aListIndexed` function can be useful if user wants to handle each element based on the index, for example:
```
 val data = forge.aListIndexed(size) { index ->
    forge.anAlphabeticalString() + index.toString()
}
```

### Reviewer checklist (to be filled by reviewers)

- [ ] All public classes, methods and fields are documented
- [ ] All code is unit tested
- [ ] All code is usable with and without the Android SDK, from Java and Kotlin
