### PR TITLE
Update Kotlin to 1.9.25

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.8.10"
+kotlin = "1.9.24"
 
 junitJupiter = "5.9.3"
 junitPlatform = "1.9.3"

--- a/inject/src/test/kotlin/fr/xgouchet/elmyr/inject/fixture/KotlinInjectedRegex.kt
+++ b/inject/src/test/kotlin/fr/xgouchet/elmyr/inject/fixture/KotlinInjectedRegex.kt
@@ -3,6 +3,7 @@ package fr.xgouchet.elmyr.inject.fixture
 import fr.xgouchet.elmyr.annotation.RegexForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 
+@Suppress("DEPRECATION")
 open class KotlinInjectedRegex {
 
     @RegexForgery("[a-z]+")

--- a/junit5/src/test/kotlin/fr/xgouchet/elmyr/junit5/ForgeExtensionTest.kt
+++ b/junit5/src/test/kotlin/fr/xgouchet/elmyr/junit5/ForgeExtensionTest.kt
@@ -1236,7 +1236,7 @@ internal class ForgeExtensionTest {
     // endregion
 }
 
-@Suppress("unused", "UNUSED_PARAMETER")
+@Suppress("unused", "UNUSED_PARAMETER", "DEPRECATION")
 internal class Reflekta(@Forgery s: String) {
 
     fun withStringForgery(@Forgery s: String) {

--- a/junit5/src/test/kotlin/fr/xgouchet/elmyr/junit5/KotlinAnnotationTest.kt
+++ b/junit5/src/test/kotlin/fr/xgouchet/elmyr/junit5/KotlinAnnotationTest.kt
@@ -25,6 +25,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
+@Suppress("UNUSED_PARAMETER")
 @ExtendWith(ForgeExtension::class)
 @ForgeConfiguration(KotlinAnnotationTest.Configurator::class)
 internal open class KotlinAnnotationTest {

--- a/junit5/src/test/kotlin/fr/xgouchet/elmyr/junit5/MockParameterContext.kt
+++ b/junit5/src/test/kotlin/fr/xgouchet/elmyr/junit5/MockParameterContext.kt
@@ -11,12 +11,15 @@ class MockParameterContext(
     private val targetParameter: Parameter
 ) : ParameterContext {
 
-    override fun <A : Annotation?> findRepeatableAnnotations(annotationType: Class<A>?): MutableList<A> {
+    override fun <A : Annotation> findRepeatableAnnotations(annotationType: Class<A>?): MutableList<A> {
         return mutableListOf()
     }
 
-    override fun <A : Annotation?> findAnnotation(annotationType: Class<A>?): Optional<A> {
-        return Optional.ofNullable(parameter.getAnnotationsByType(annotationType).firstOrNull())
+    override fun <A : Annotation> findAnnotation(annotationType: Class<A>?): Optional<A> {
+        return Optional.ofNullable(
+            parameter.getAnnotationsByType(annotationType)
+                .firstOrNull()
+        )
     }
 
     override fun getParameter(): Parameter {
@@ -31,7 +34,7 @@ class MockParameterContext(
         return Optional.empty()
     }
 
-    override fun isAnnotated(annotationType: Class<out Annotation>?): Boolean {
+    override fun isAnnotated(annotationType: Class<out Annotation>): Boolean {
         return targetParameter.isAnnotationPresent(annotationType)
     }
 }

--- a/semantics/src/main/kotlin/fr/xgouchet/elmyr/semantics/StringExt.kt
+++ b/semantics/src/main/kotlin/fr/xgouchet/elmyr/semantics/StringExt.kt
@@ -1,0 +1,14 @@
+package fr.xgouchet.elmyr.semantics
+
+import java.util.Locale
+
+/**
+ * Returns a copy of this string having its first letter title-cased,
+ * using the rules of the provided locale.
+ * @param locale the Locale to use (default: [Locale.US])
+ */
+fun String.capitalized(locale: Locale = Locale.US): String {
+    return replaceFirstChar {
+        if (it.isLowerCase()) it.titlecase(locale) else it.toString()
+    }
+}

--- a/semantics/src/test/kotlin/fr/xgouchet/elmyr/semantics/markov/MarkovReaderTest.kt
+++ b/semantics/src/test/kotlin/fr/xgouchet/elmyr/semantics/markov/MarkovReaderTest.kt
@@ -2,6 +2,7 @@ package fr.xgouchet.elmyr.semantics.markov
 
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import fr.xgouchet.elmyr.semantics.capitalized
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -20,7 +21,7 @@ class MarkovReaderTest {
         assertThat(table.chainLength)
             .isEqualTo(4)
 
-        println("Gen first name: ${table.generate(forge).capitalize()}")
+        println("Gen first name: ${table.generate(forge).capitalized()}")
     }
 
     @Test
@@ -34,7 +35,7 @@ class MarkovReaderTest {
         assertThat(table.chainLength)
             .isEqualTo(4)
 
-        println("Gen last name: ${table.generate(forge).capitalize()}")
+        println("Gen last name: ${table.generate(forge).capitalized()}")
     }
 
     @Test
@@ -48,6 +49,6 @@ class MarkovReaderTest {
         assertThat(table.chainLength)
             .isEqualTo(4)
 
-        println("Gen lipsum: ${table.generate(forge).capitalize()}")
+        println("Gen lipsum: ${table.generate(forge).capitalized()}")
     }
 }

--- a/spek/src/test/kotlin/fr/xgouchet/elmyr/spek/ForgeLifecycleListenerTest.kt
+++ b/spek/src/test/kotlin/fr/xgouchet/elmyr/spek/ForgeLifecycleListenerTest.kt
@@ -74,6 +74,7 @@ internal class ForgeLifecycleListenerTest {
 
     lateinit var testedListener: ForgeLifecycleListener
 
+    @Suppress("DEPRECATION")
     @RegexForgery("([a-z]{2,5}\\.){4}")
     lateinit var fakeRootPackage: String
 


### PR DESCRIPTION
### What?

Updates the Kotlin dependency to `1.9.24` (5 month old version at the time of making this PR)

